### PR TITLE
remove deals from the DealsTable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .idea
+
+NOTES.MD

--- a/question_and_answers.MD
+++ b/question_and_answers.MD
@@ -1,0 +1,7 @@
+# Questions and Answers 
+
+### NewDealForm will rerender some of its children unnecessarily. Why? What is the generally recommended solution?
+
+I believe NewDealForm is unnecessarily rerendering all of the inputs because onChange is expecting an uninvoked function. I believe it would be standard procedure to use a fat arrow function that returns propertyUpdater function invoked.
+
+``` e.g. onChange={() => this.propertyUpdater('dealType')} ```

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,10 +1,20 @@
 export const CREATE_DEAL = 'CREATE_DEAL';
+export const DELETE_DEAL = 'DELETE_DEAL';
 
 export function createDeal(deal) {
   return {
     type: CREATE_DEAL,
     payload: {
       deal
+    }
+  }
+}
+
+export function deleteDeal(id) {
+  return {
+    type: DELETE_DEAL,
+    payload: {
+      id
     }
   }
 }

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -22,6 +22,12 @@
   font-size: large;
 }
 
+.DealsPage--button {
+  font-size: 20px;
+  margin-top: 10px;
+  width: 300px;
+}
+
 @keyframes App-logo-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }

--- a/src/components/DealsTable.js
+++ b/src/components/DealsTable.js
@@ -19,8 +19,8 @@ class DealsList extends Component {
   }
 
   render() {
-    const { deals } = this.props;
-    const dealsTableRows = deals.map(deal => <DealsTableRow key={deal.id} deal={deal} />);
+    const { deals, onDeleteDeal } = this.props;
+    const dealsTableRows = deals.map(deal => <DealsTableRow key={deal.id} deal={deal} onDeleteDeal={onDeleteDeal} />);
     return(
       <div>
         <table className="DealsTable">
@@ -30,6 +30,7 @@ class DealsList extends Component {
               <th className="DealsTable--headerCell">Deal Type</th>
               <th className="DealsTable--headerCell">Deal Size</th>
               <th className="DealsTable--headerCell">Is Published?</th>
+              <th className="DealsTable--headerCell">Manage</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/DealsTableRow.js
+++ b/src/components/DealsTableRow.js
@@ -10,6 +10,7 @@ function currencyAmountToString(amount) {
 class DealsTableRow extends Component {
   static propTypes = {
     deal: PropTypes.shape({
+      id: PropTypes.number.isRequired,
       institution: PropTypes.string.isRequired,
       dealType: PropTypes.string.isRequired,
       dealSize: PropTypes.string.isRequired,
@@ -18,13 +19,16 @@ class DealsTableRow extends Component {
   }
 
   render() {
-    const { deal: { institution, dealType, dealSize, isPublished } } = this.props;
+    const { deal: { id, institution, dealType, dealSize, isPublished }, onDeleteDeal } = this.props;
     return (
       <tr className="DealsTableRow">
         <td className="DealsTableRow--cell">{institution}</td>
         <td className="DealsTableRow--cell">{dealType}</td>
         <td className="DealsTableRow--cell">{currencyAmountToString(dealSize)}</td>
         <td className="DealsTableRow--cell">{isPublished ? 'Yes' : 'No'}</td>
+        <td className="DealsTableRow--cell">
+          <button className="DealsPage--button" onClick={() => onDeleteDeal(id)}> Delete </button>
+        </td>
       </tr>
     )
   }

--- a/src/components/NewDealForm.js
+++ b/src/components/NewDealForm.js
@@ -76,7 +76,7 @@ class DealForm extends Component {
             />
           </label>
         </div>
-        <button className="NewDealForm--button" onClick={this.createDeal}>Create Deal</button>
+        <button className="DealsPage--button" onClick={this.createDeal}>Create Deal</button>
       </form>
     );
   }

--- a/src/containers/DealsTableWithData.js
+++ b/src/containers/DealsTableWithData.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { deleteDeal } from '../actions';
 import DealsTable from '../components/DealsTable';
 
 const mapStateToProps = state => {
@@ -8,4 +9,10 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(DealsTable);
+const mapDispatchToProps = dispatch => {
+  return {
+    onDeleteDeal: id => dispatch(deleteDeal(id))
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DealsTable);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,4 +1,5 @@
-import { CREATE_DEAL } from './actions';
+import { CREATE_DEAL, DELETE_DEAL } from './actions';
+import _ from 'lodash';
 
 var nextDealId = 3;
 
@@ -25,6 +26,13 @@ export default (state = initialState, { type, payload }) => {
   switch(type) {
     case CREATE_DEAL:
       return { ...state, deals: [ ...state.deals, { ...payload.deal, id: nextDealId++ } ] };
+    case DELETE_DEAL:
+      const newDeals = _.map(state.deals, (deal) => {
+        if (deal.id != payload.id) {
+          return deal;
+        }
+      });
+        return {...state, deals: newDeals }
     default:
       return state;
   }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,5 @@
 import { CREATE_DEAL, DELETE_DEAL } from './actions';
-import _ from 'lodash';
+import { filter } from 'lodash';
 
 var nextDealId = 3;
 
@@ -27,12 +27,8 @@ export default (state = initialState, { type, payload }) => {
     case CREATE_DEAL:
       return { ...state, deals: [ ...state.deals, { ...payload.deal, id: nextDealId++ } ] };
     case DELETE_DEAL:
-      const newDeals = _.map(state.deals, (deal) => {
-        if (deal.id != payload.id) {
-          return deal;
-        }
-      });
-        return {...state, deals: newDeals }
+      const newDeals = filter(state.deals, deal => deal.id !== payload.id);
+      return {...state, deals: newDeals };
     default:
       return state;
   }


### PR DESCRIPTION
My responses to questions can be found in the file 'questions_and_answers.md' in the root directory.

I decided to implement the ability to remove deals from the table. I started with the action, then set the reducer to listen for the type: DELETE_DEAL. Next, deleteDeal was mappedToDispatch in the DealsTableWithData container and passed down via props to DealsTableRow.

Because I implemented the action/reducer to filter via id, I added 'id' to the PropTypes check for consistency. 

A bug I came across while developing this feature: using lodash's map feature in the reducer led to undefined values in the deals array. This led to errors of cannot read property X of undefined and I fixed it by using lodash's filter feature (returning a new array of all elements predicate returns truthy for). 

